### PR TITLE
Fix typings and webpack externals config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@concord-consortium/text-decorator",
-	"version": "1.0.0",
+	"version": "1.0.2",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -873,6 +873,7 @@
 			"resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
 			"integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
 			"dev": true,
+			"optional": true,
 			"requires": {
 				"kind-of": "^3.0.2",
 				"longest": "^1.0.1",
@@ -4994,7 +4995,8 @@
 				"ansi-regex": {
 					"version": "2.1.1",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"aproba": {
 					"version": "1.2.0",
@@ -5015,12 +5017,14 @@
 				"balanced-match": {
 					"version": "1.0.0",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"brace-expansion": {
 					"version": "1.1.11",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"balanced-match": "^1.0.0",
 						"concat-map": "0.0.1"
@@ -5035,17 +5039,20 @@
 				"code-point-at": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"concat-map": {
 					"version": "0.0.1",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"core-util-is": {
 					"version": "1.0.2",
@@ -5162,7 +5169,8 @@
 				"inherits": {
 					"version": "2.0.3",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"ini": {
 					"version": "1.3.5",
@@ -5174,6 +5182,7 @@
 					"version": "1.0.0",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
@@ -5188,6 +5197,7 @@
 					"version": "3.0.4",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"brace-expansion": "^1.1.7"
 					}
@@ -5195,12 +5205,14 @@
 				"minimist": {
 					"version": "0.0.8",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"minipass": {
 					"version": "2.2.4",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"safe-buffer": "^5.1.1",
 						"yallist": "^3.0.0"
@@ -5219,6 +5231,7 @@
 					"version": "0.5.1",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"minimist": "0.0.8"
 					}
@@ -5299,7 +5312,8 @@
 				"number-is-nan": {
 					"version": "1.0.1",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"object-assign": {
 					"version": "4.1.1",
@@ -5311,6 +5325,7 @@
 					"version": "1.4.0",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"wrappy": "1"
 					}
@@ -5396,7 +5411,8 @@
 				"safe-buffer": {
 					"version": "5.1.1",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"safer-buffer": {
 					"version": "2.1.2",
@@ -5432,6 +5448,7 @@
 					"version": "1.0.2",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"code-point-at": "^1.0.0",
 						"is-fullwidth-code-point": "^1.0.0",
@@ -5451,6 +5468,7 @@
 					"version": "3.0.1",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
@@ -5494,12 +5512,14 @@
 				"wrappy": {
 					"version": "1.0.2",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"yallist": {
 					"version": "3.0.2",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				}
 			}
 		},

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@concord-consortium/text-decorator",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "The TextDecorator library provides text decoration capabilities for HTML and React apps",
   "keywords": [
     "text",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@concord-consortium/text-decorator",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "The TextDecorator library provides text decoration capabilities for HTML and React apps",
   "keywords": [
     "text",
@@ -11,10 +11,10 @@
     "parse"
   ],
   "main": "dist/text-decorator.js",
-  "files": [
-    "dist/library"
-  ],
   "typings": "dist/types/text-decorator.d.ts",
+  "files": [
+    "dist"
+  ],
   "author": "Concord Consortium <developer@concord.org>",
   "repository": {
     "type": "git",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -55,8 +55,18 @@ module.exports = (env, argv) => {
       warningsFilter: /export .* was not found in/
     },
     externals: {
-      'react': 'React',
-      'react-dom': 'ReactDOM'
+      'react': {
+        commonjs: 'react',
+        commonjs2: 'react',
+        amd: 'react',
+        root: 'React'
+      },
+      'react-dom': {
+        commonjs: 'react-dom',
+        commonjs2: 'react-dom',
+        amd: 'react-dom',
+        root: 'ReactDOM'
+      }
     },
     plugins: [
       new ForkTsCheckerWebpackPlugin()


### PR DESCRIPTION
1. Typings were not included in NPM package, "packages#files" update fixes that.

2. Webpack external config wasn't sufficient for UMD needs. This is actually a quite interesting case. Previous config was working fine when this library was embedded in LARA directly that exposes React as `window.React`. But it didn't work when I tried to import this library in another NPM package => in commonjs environment (LARA Plugin API package). Webpack was trying to import "React" instead of "react". So, it turns out that providing full configuration for externals is worth the effort.